### PR TITLE
Review and fix dashboard data and graphs

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -67,7 +67,7 @@ services:
     image: grafana/grafana:latest
     container_name: grafana
     ports:
-      - "3000:3000"
+      - "8080:3000"
     environment:
       - GF_SECURITY_ADMIN_USER=admin
       - GF_SECURITY_ADMIN_PASSWORD=${GF_SECURITY_ADMIN_PASSWORD}

--- a/grafana/provisioning/datasources/datasource.yml
+++ b/grafana/provisioning/datasources/datasource.yml
@@ -5,12 +5,11 @@ datasources:
     type: influxdb
     access: proxy
     url: http://influxdb:8086
-    database: ha_events
-    user: admin
-    secureJsonData:
-      password: ${INFLUXDB_TOKEN}
     jsonData:
+      httpMode: POST
       version: Flux
-      organization: myorg
-      defaultBucket: ha_events
+      organization: ${INFLUXDB_ORG}
+      defaultBucket: ${INFLUXDB_BUCKET}
       tlsSkipVerify: true
+    secureJsonData:
+      token: ${INFLUXDB_TOKEN}


### PR DESCRIPTION
## 🚀 Pull Request Description
This PR addresses issues with the dashboard on port 8080, where data was not displaying correctly and graphs were empty. The changes involve reconfiguring Grafana's port mapping and updating its InfluxDB datasource to correctly fetch data.

## 🔍 Related Issues
Closes #
Related to #

## 📋 Changes Made
- [ ] **Bug Fix**: Corrected Grafana port mapping and InfluxDB datasource configuration.
- [ ] **Refactoring**: Updated InfluxDB datasource to use Flux with token-based authentication and environment variables for organization and bucket.

## 🧪 Testing
- [ ] **Manual Testing**: Tested manually by bringing up the services and verifying dashboard data on `http://localhost:8080`.

## 📱 Environment
- **OS**: Linux
- **Python Version**: N/A
- **Home Assistant Version**: N/A

## 📸 Screenshots
N/A

## 📝 Checklist
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

## 🔧 Additional Notes
- Grafana is now exposed on port `8080`.
- The InfluxDB datasource is configured to use Flux query language with token-based authentication.
- Ensure the following environment variables are set in your `.env` file for Grafana to connect to InfluxDB: `INFLUXDB_TOKEN`, `INFLUXDB_ORG`, and `INFLUXDB_BUCKET`. The `INFLUXDB_BUCKET` should match the bucket where `ha_ingestor` writes data (e.g., `home_assistant_events`).

---
<a href="https://cursor.com/background-agent?bcId=bc-e406c592-22bf-4ec2-b5bf-9369979a3c2f">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-e406c592-22bf-4ec2-b5bf-9369979a3c2f">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

