### PR TITLE
fix: restore test infrastructure and fix all unit tests after upgrade

### DIFF
--- a/services/health-dashboard/package-lock.json
+++ b/services/health-dashboard/package-lock.json
@@ -17,6 +17,7 @@
       },
       "devDependencies": {
         "@playwright/test": "^1.48.2",
+        "@testing-library/jest-dom": "^6.9.1",
         "@testing-library/react": "^16.3.0",
         "@testing-library/user-event": "^14.6.1",
         "@types/react": "^18.3.5",
@@ -37,6 +38,13 @@
         "vite": "^5.4.8",
         "vitest": "^3.2.4"
       }
+    },
+    "node_modules/@adobe/css-tools": {
+      "version": "4.4.4",
+      "resolved": "https://registry.npmjs.org/@adobe/css-tools/-/css-tools-4.4.4.tgz",
+      "integrity": "sha512-Elp+iwUx5rN5+Y8xLt5/GRoG20WGoDCQ/1Fb+1LiGtvwbDavuSk0jhD/eZdckHAuzcDzccnkv+rEjyWfRx18gg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@alloc/quick-lru": {
       "version": "5.2.0",
@@ -1620,6 +1628,33 @@
         "node": ">=18"
       }
     },
+    "node_modules/@testing-library/jest-dom": {
+      "version": "6.9.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/jest-dom/-/jest-dom-6.9.1.tgz",
+      "integrity": "sha512-zIcONa+hVtVSSep9UT3jZ5rizo2BsxgyDYU7WFD5eICBE7no3881HGeb/QkGfsJs6JTkY1aQhT7rIPC7e+0nnA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@adobe/css-tools": "^4.4.0",
+        "aria-query": "^5.0.0",
+        "css.escape": "^1.5.1",
+        "dom-accessibility-api": "^0.6.3",
+        "picocolors": "^1.1.1",
+        "redent": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=14",
+        "npm": ">=6",
+        "yarn": ">=1"
+      }
+    },
+    "node_modules/@testing-library/jest-dom/node_modules/dom-accessibility-api": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.6.3.tgz",
+      "integrity": "sha512-7ZgogeTnjuHbo+ct10G9Ffp0mif17idi0IyWNVA/wcwcm7NPOD/WEHVP3n7n3MhXqxoIYm8d6MuZohYWIZ4T3w==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@testing-library/react": {
       "version": "16.3.0",
       "resolved": "https://registry.npmjs.org/@testing-library/react/-/react-16.3.0.tgz",
@@ -2320,7 +2355,6 @@
       "integrity": "sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "dequal": "^2.0.3"
       }
@@ -2758,6 +2792,13 @@
         "node": ">= 8"
       }
     },
+    "node_modules/css.escape": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/css.escape/-/css.escape-1.5.1.tgz",
+      "integrity": "sha512-YUifsXXuknHlUsmlgyY0PKzgPOr7/FjCePfHNt0jxm83wHZi44VDMQ7/fGNkjY3/jV1MC+1CmZbaHzugyeRtpg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/cssesc": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/cssesc/-/cssesc-3.0.0.tgz",
@@ -2946,7 +2987,6 @@
       "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=6"
       }
@@ -3743,6 +3783,16 @@
         "node": ">=0.8.19"
       }
     },
+    "node_modules/indent-string": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-4.0.0.tgz",
+      "integrity": "sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/inflight": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
@@ -4098,6 +4148,16 @@
       },
       "engines": {
         "node": ">=8.6"
+      }
+    },
+    "node_modules/min-indent": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/min-indent/-/min-indent-1.0.1.tgz",
+      "integrity": "sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
       }
     },
     "node_modules/minimatch": {
@@ -4941,6 +5001,20 @@
         "react-is": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
+    "node_modules/redent": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/redent/-/redent-3.0.0.tgz",
+      "integrity": "sha512-6tDA8g98We0zd0GvVeMT9arEOnTw9qM03L9cJXaCjrip1OO764RDBLBfrB4cwzNGDj5OA5ioymC9GkizgWJDUg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "indent-string": "^4.0.0",
+        "strip-indent": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/redux": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/redux/-/redux-5.0.1.tgz",
@@ -5327,6 +5401,19 @@
       "license": "MIT",
       "dependencies": {
         "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-indent": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-3.0.0.tgz",
+      "integrity": "sha512-laJTa3Jb+VQpaC6DseHhF7dXVqHTfJPCRDaEbid/drOhgitgYku/letMUqOXFoWV0zIIUbjpdH2t+tYj4bQMRQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "min-indent": "^1.0.0"
       },
       "engines": {
         "node": ">=8"

--- a/services/health-dashboard/package.json
+++ b/services/health-dashboard/package.json
@@ -35,6 +35,7 @@
   },
   "devDependencies": {
     "@playwright/test": "^1.48.2",
+    "@testing-library/jest-dom": "^6.9.1",
     "@testing-library/react": "^16.3.0",
     "@testing-library/user-event": "^14.6.1",
     "@types/react": "^18.3.5",

--- a/services/health-dashboard/src/__tests__/useTeamPreferences.test.ts
+++ b/services/health-dashboard/src/__tests__/useTeamPreferences.test.ts
@@ -123,20 +123,20 @@ describe('useTeamPreferences', () => {
   });
 
   it('should load from localStorage on init', () => {
-    // Pre-populate localStorage
+    // Pre-populate localStorage with version 2 format
     localStorage.setItem('sports_selected_teams', JSON.stringify({
-      nfl_teams: ['gb', 'kc'],
-      nhl_teams: ['pit'],
+      nfl_teams: ['nfl-gb', 'nfl-kc'],
+      nhl_teams: ['nhl-bos'],
       setup_completed: true,
       last_updated: new Date().toISOString(),
-      version: 1
+      version: 2
     }));
 
     const { result } = renderHook(() => useTeamPreferences());
 
     expect(result.current.loading).toBe(false);
-    expect(result.current.nflTeams).toEqual(['gb', 'kc']);
-    expect(result.current.nhlTeams).toEqual(['pit']);
+    expect(result.current.nflTeams).toEqual(['nfl-gb', 'nfl-kc']);
+    expect(result.current.nhlTeams).toEqual(['nhl-bos']);
     expect(result.current.setupCompleted).toBe(true);
   });
 

--- a/services/health-dashboard/src/components/__tests__/Dashboard.interactions.test.tsx
+++ b/services/health-dashboard/src/components/__tests__/Dashboard.interactions.test.tsx
@@ -77,9 +77,10 @@ describe('Dashboard User Interactions', () => {
     // Test navigating to each tab
     const tabs = [
       'Overview',
-      'Custom',
+      'Setup',
       'Services',
       'Dependencies',
+      'Devices',
       'Events',
       'Logs',
       'Sports',
@@ -88,9 +89,9 @@ describe('Dashboard User Interactions', () => {
     for (const tabName of tabs) {
       const tab = screen.getByRole('button', { name: new RegExp(tabName, 'i') });
       await user.click(tab);
-      
-      // Verify tab is active
-      expect(tab).toHaveClass('bg-blue-600');
+
+      // Verify tab is active (has blue background class in light mode)
+      expect(tab).toHaveClass('bg-blue-100');
     }
   });
 });

--- a/services/health-dashboard/src/components/__tests__/Dashboard.test.tsx
+++ b/services/health-dashboard/src/components/__tests__/Dashboard.test.tsx
@@ -20,16 +20,16 @@ describe('Dashboard Component', () => {
   it('switches active tab when navigation button is clicked', async () => {
     const user = userEvent.setup();
     render(<Dashboard />);
-    
+
     // Wait for dashboard to load
     await screen.findByRole('heading', { name: /HA Ingestor Dashboard/i });
-    
+
     // Find and click the Services tab
     const servicesTab = screen.getByRole('button', { name: /Services/i });
     await user.click(servicesTab);
-    
-    // Verify the tab is now active (has blue background class)
-    expect(servicesTab).toHaveClass('bg-blue-600');
+
+    // Verify the tab is now active (has blue background class in light mode)
+    expect(servicesTab).toHaveClass('bg-blue-100');
   });
 
   it('toggles dark mode when theme button is clicked', async () => {

--- a/services/health-dashboard/src/hooks/__tests__/useStatistics.test.ts
+++ b/services/health-dashboard/src/hooks/__tests__/useStatistics.test.ts
@@ -5,10 +5,6 @@ import { server } from '../../tests/mocks/server';
 import { http, HttpResponse } from 'msw';
 
 describe('useStatistics Hook', () => {
-  beforeEach(() => {
-    vi.useFakeTimers();
-  });
-
   afterEach(() => {
     // ✅ Context7 Best Practice: Cleanup after each test
     vi.useRealTimers();
@@ -18,17 +14,17 @@ describe('useStatistics Hook', () => {
 
   it('displays statistics data when API responds successfully', async () => {
     const { result } = renderHook(() => useStatistics('1h', 1000));
-    
+
     // Initially loading
     expect(result.current.loading).toBe(true);
     expect(result.current.statistics).toBeNull();
     expect(result.current.error).toBeNull();
-    
+
     // Wait for data to load
     await waitFor(() => {
       expect(result.current.loading).toBe(false);
     });
-    
+
     // Verify statistics data is populated
     expect(result.current.statistics).toBeDefined();
     expect(result.current.statistics?.total_events).toBe(12345);
@@ -39,18 +35,18 @@ describe('useStatistics Hook', () => {
   it('shows error message when statistics API returns error', async () => {
     // Mock API to return 500 error
     server.use(
-      http.get('/api/stats', () => {
+      http.get('http://localhost:8003/api/v1/stats', () => {
         return new HttpResponse(null, { status: 500, statusText: 'Internal Server Error' });
       })
     );
-    
+
     const { result } = renderHook(() => useStatistics('1h', 1000));
-    
+
     // Wait for error to be set
     await waitFor(() => {
       expect(result.current.loading).toBe(false);
     });
-    
+
     // Verify error state
     expect(result.current.statistics).toBeNull();
     expect(result.current.error).toBeDefined();
@@ -59,9 +55,9 @@ describe('useStatistics Hook', () => {
 
   it('passes correct period parameter to API request', async () => {
     let requestedPeriod = '';
-    
+
     server.use(
-      http.get('/api/stats', ({ request }) => {
+      http.get('http://localhost:8003/api/v1/stats', ({ request }) => {
         const url = new URL(request.url);
         requestedPeriod = url.searchParams.get('period') || '';
         return HttpResponse.json({
@@ -71,13 +67,13 @@ describe('useStatistics Hook', () => {
         });
       })
     );
-    
+
     const { result } = renderHook(() => useStatistics('24h', 1000));
-    
+
     await waitFor(() => {
       expect(result.current.loading).toBe(false);
     });
-    
+
     // Verify period parameter was passed correctly
     expect(requestedPeriod).toBe('24h');
   });

--- a/services/health-dashboard/src/tests/mocks/handlers.ts
+++ b/services/health-dashboard/src/tests/mocks/handlers.ts
@@ -1,0 +1,97 @@
+import { http, HttpResponse } from 'msw';
+
+// Mock API response handlers for testing
+export const handlers = [
+  // Health endpoint (used by useHealth hook)
+  http.get('http://localhost:8003/api/health', () => {
+    return HttpResponse.json({
+      overall_status: 'healthy',
+      timestamp: new Date().toISOString(),
+      ingestion_service: {
+        websocket_connection: {
+          is_connected: true,
+          connection_attempts: 5,
+        },
+        event_processing: {
+          status: 'healthy',
+          events_per_minute: 42,
+          total_events: 12345,
+          error_rate: 0.5,
+        },
+        influxdb_storage: {
+          is_connected: true,
+          write_errors: 0,
+        },
+        weather_enrichment: {
+          api_calls: 150,
+        },
+      },
+    });
+  }),
+
+  // Enhanced health endpoint
+  http.get('http://localhost:8003/api/v1/health', () => {
+    return HttpResponse.json({
+      overall_status: 'healthy',
+      timestamp: new Date().toISOString(),
+      ingestion_service: {
+        websocket_connection: {
+          is_connected: true,
+          connection_attempts: 5,
+        },
+        event_processing: {
+          status: 'healthy',
+          events_per_minute: 42,
+          total_events: 12345,
+          error_rate: 0.5,
+        },
+        influxdb_storage: {
+          is_connected: true,
+          write_errors: 0,
+        },
+        weather_enrichment: {
+          api_calls: 150,
+        },
+      },
+    });
+  }),
+
+  // Statistics endpoint (used by useStatistics hook)
+  http.get('http://localhost:8003/api/v1/stats', () => {
+    return HttpResponse.json({
+      total_events: 12345,
+      events_per_minute: 42,
+      error_rate: 0.5,
+      uptime_hours: 24.5,
+    });
+  }),
+
+  // Data sources endpoint
+  http.get('/api/v1/data-sources', () => {
+    return HttpResponse.json({
+      weather: { status: 'active', last_update: new Date().toISOString() },
+      carbon: { status: 'active', last_update: new Date().toISOString() },
+      sports: { status: 'active', last_update: new Date().toISOString() },
+    });
+  }),
+
+  // Services endpoint
+  http.get('/api/v1/services', () => {
+    return HttpResponse.json({
+      services: [
+        {
+          id: 'websocket',
+          name: 'WebSocket Ingestion',
+          status: 'healthy',
+          dependencies: ['influxdb'],
+        },
+        {
+          id: 'enrichment',
+          name: 'Enrichment Pipeline',
+          status: 'healthy',
+          dependencies: ['influxdb'],
+        },
+      ],
+    });
+  }),
+];

--- a/services/health-dashboard/src/tests/mocks/server.ts
+++ b/services/health-dashboard/src/tests/mocks/server.ts
@@ -1,0 +1,5 @@
+import { setupServer } from 'msw/node';
+import { handlers } from './handlers';
+
+// Setup requests interception using the given handlers
+export const server = setupServer(...handlers);

--- a/services/health-dashboard/src/tests/setup.ts
+++ b/services/health-dashboard/src/tests/setup.ts
@@ -1,0 +1,21 @@
+import { beforeAll, afterEach, afterAll, vi } from 'vitest';
+import { server } from './mocks/server';
+import '@testing-library/jest-dom/vitest';
+
+// Context7 pattern: Use environment variables in MSW setup
+const WS_URL = import.meta.env.VITE_WS_URL || 'ws://localhost:8001';
+
+// Mock WebSocket with environment-based URL
+global.WebSocket = vi.fn().mockImplementation(() => {
+  return {
+    addEventListener: vi.fn(),
+    removeEventListener: vi.fn(),
+    send: vi.fn(),
+    close: vi.fn(),
+    readyState: 1, // OPEN
+  };
+}) as any;
+
+beforeAll(() => server.listen({ onUnhandledRequest: 'warn' }));
+afterEach(() => server.resetHandlers());
+afterAll(() => server.close());

--- a/services/health-dashboard/src/tests/test-utils.tsx
+++ b/services/health-dashboard/src/tests/test-utils.tsx
@@ -1,0 +1,11 @@
+import { ReactElement } from 'react';
+import { render, RenderOptions } from '@testing-library/react';
+
+// Custom render function with common providers
+const customRender = (
+  ui: ReactElement,
+  options?: Omit<RenderOptions, 'wrapper'>
+) => render(ui, { ...options });
+
+export * from '@testing-library/react';
+export { customRender as render };


### PR DESCRIPTION
Restored missing test setup files and fixed all failing unit tests after
the 3rd party node components upgrade.

Changes:
- Created missing test setup files (setup.ts, test-utils.tsx, MSW handlers)
- Installed @testing-library/jest-dom for DOM matchers
- Fixed MSW handlers to use correct API endpoints (http://localhost:8003)
- Updated test expectations for light mode tab classes (bg-blue-100)
- Fixed useTeamPreferences test to use v2 team format
- Removed fake timers from hook tests to fix timeout issues
- Updated Dashboard interactions test to use correct tab names

All 39 tests now pass successfully (7 test files).