### PR TITLE
Reset MSW handlers in useStatistics tests

### DIFF
--- a/services/health-dashboard/src/hooks/__tests__/useStatistics.test.ts
+++ b/services/health-dashboard/src/hooks/__tests__/useStatistics.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { describe, it, expect, afterEach, vi } from 'vitest';
 import { renderHook, waitFor } from '@testing-library/react';
 import { useStatistics } from '../useStatistics';
 import { server } from '../../tests/mocks/server';

--- a/services/health-dashboard/src/hooks/__tests__/useStatistics.test.ts
+++ b/services/health-dashboard/src/hooks/__tests__/useStatistics.test.ts
@@ -7,6 +7,7 @@ import { http, HttpResponse } from 'msw';
 describe('useStatistics Hook', () => {
   afterEach(() => {
     // ✅ Context7 Best Practice: Cleanup after each test
+    server.resetHandlers();
     vi.useRealTimers();
     vi.clearAllMocks();
     vi.unstubAllGlobals();


### PR DESCRIPTION
## Summary
- ensure the useStatistics test suite resets the MSW server handlers after each test for better isolation

## Testing
- npx vitest run services/health-dashboard/src/hooks/__tests__/useStatistics.test.ts *(fails: npm error 403 when attempting to download vitest)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6917b46e6a4c832bb7e5d5095104cc46)