### PR TITLE
Fix service health API mapping

### DIFF
--- a/services/health-dashboard/src/components/DataSourcesPanel.tsx
+++ b/services/health-dashboard/src/components/DataSourcesPanel.tsx
@@ -7,7 +7,7 @@
 
 import React, { useState, useEffect } from 'react';
 import { useDataSources } from '../hooks/useDataSources';
-import { DataSourceHealth } from '../types';
+import { DataSourcesHealthMap } from '../types';
 import { SkeletonCard } from './skeletons';
 
 interface DataSourcesPanelProps {
@@ -15,7 +15,9 @@ interface DataSourcesPanelProps {
 }
 
 // Data source definitions for display
-const DATA_SOURCE_DEFINITIONS = [
+type DataSourceKey = keyof DataSourcesHealthMap;
+
+const DATA_SOURCE_DEFINITIONS: Array<{ id: DataSourceKey; name: string; icon: string; }> = [
   { id: 'weather', name: 'Weather API', icon: '☁️' },
   { id: 'carbonIntensity', name: 'Carbon Intensity', icon: '🌱' },
   { id: 'airQuality', name: 'Air Quality', icon: '💨' },
@@ -196,9 +198,12 @@ export const DataSourcesPanel: React.FC<DataSourcesPanelProps> = ({ darkMode }) 
       {/* Data Source Cards */}
       <div className="grid grid-cols-1 md:grid-cols-2 xl:grid-cols-3 gap-6">
         {DATA_SOURCE_DEFINITIONS.map(sourceDef => {
-          const source = dataSources?.[sourceDef.id as keyof typeof dataSources];
+          const source = dataSources?.[sourceDef.id] ?? null;
           const status = source?.status || 'unknown';
-          
+          const statusDetail = source?.status_detail;
+          const credentialsConfigured = source?.credentials_configured;
+          const apiUsage = source?.api_usage;
+
           return (
             <div
               key={sourceDef.id}
@@ -215,9 +220,9 @@ export const DataSourcesPanel: React.FC<DataSourcesPanelProps> = ({ darkMode }) 
                       {sourceDef.name}
                     </h3>
                     <div className={`flex items-center gap-2 text-sm ${getStatusColor(status)}`}>
-                      <span>{getStatusIcon(status, source.status_detail, source.credentials_configured)}</span>
+                      <span>{getStatusIcon(status, statusDetail, credentialsConfigured)}</span>
                       <span className="capitalize">
-                        {source.status_detail === 'credentials_missing' || source.credentials_configured === false
+                        {statusDetail === 'credentials_missing' || credentialsConfigured === false
                           ? 'Credentials Needed'
                           : status}
                       </span>
@@ -247,37 +252,37 @@ export const DataSourcesPanel: React.FC<DataSourcesPanelProps> = ({ darkMode }) 
               )}
 
               {/* API Usage */}
-              {source.api_usage && (
+              {apiUsage && (
                 <div className="mb-4">
                   <div className={`text-sm font-medium ${darkMode ? 'text-gray-300' : 'text-gray-700'} mb-2`}>
                   API Usage Today
                   </div>
                   <div className="flex items-baseline gap-2">
                     <span className={`text-2xl font-bold ${darkMode ? 'text-white' : 'text-gray-900'}`}>
-                      {source.api_usage.calls_today}
+                      {apiUsage.calls_today}
                     </span>
-                    {source.api_usage.quota_limit && (
+                    {apiUsage.quota_limit && (
                       <span className={`text-sm ${darkMode ? 'text-gray-400' : 'text-gray-600'}`}>
-                      / {source.api_usage.quota_limit}
+                      / {apiUsage.quota_limit}
                       </span>
                     )}
                   </div>
-                  {source.api_usage.quota_percentage !== undefined && source.api_usage.quota_percentage > 0 && (
+                  {apiUsage.quota_percentage !== undefined && apiUsage.quota_percentage > 0 && (
                     <div className="mt-2">
                       <div className="h-2 bg-gray-200 dark:bg-gray-700 rounded-full overflow-hidden">
                         <div
                           className={`h-full rounded-full transition-all ${
-                            source.api_usage.quota_percentage > 80
+                            apiUsage.quota_percentage > 80
                               ? 'bg-red-500'
-                              : source.api_usage.quota_percentage > 60
+                              : apiUsage.quota_percentage > 60
                                 ? 'bg-yellow-500'
                                 : 'bg-green-500'
                           }`}
-                          style={{ width: `${source.api_usage.quota_percentage}%` }}
+                          style={{ width: `${apiUsage.quota_percentage}%` }}
                         />
                       </div>
                       <span className={`text-xs ${darkMode ? 'text-gray-400' : 'text-gray-600'}`}>
-                        {source.api_usage.quota_percentage}% of quota used
+                        {apiUsage.quota_percentage}% of quota used
                       </span>
                     </div>
                   )}

--- a/services/health-dashboard/src/hooks/useDataSources.ts
+++ b/services/health-dashboard/src/hooks/useDataSources.ts
@@ -1,16 +1,9 @@
 import { useState, useEffect } from 'react';
 import { apiService } from '../services/api';
-import { DataSourceHealth } from '../types';
+import { DataSourcesHealthMap } from '../types';
 
 export const useDataSources = (refreshInterval: number = 30000) => {
-  const [dataSources, setDataSources] = useState<{
-    weather: DataSourceHealth | null;
-    carbonIntensity: DataSourceHealth | null;
-    electricityPricing: DataSourceHealth | null;
-    airQuality: DataSourceHealth | null;
-    calendar: DataSourceHealth | null;
-    smartMeter: DataSourceHealth | null;
-  } | null>(null);
+  const [dataSources, setDataSources] = useState<DataSourcesHealthMap | null>(null);
   
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);

--- a/services/health-dashboard/src/services/__tests__/api.test.ts
+++ b/services/health-dashboard/src/services/__tests__/api.test.ts
@@ -1,0 +1,55 @@
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { apiService } from '../api';
+import type { ServicesHealthResponse } from '../../types/health';
+
+const mockServicesHealth: ServicesHealthResponse = {
+  'weather-api': {
+    name: 'Weather API',
+    status: 'healthy',
+    last_check: '2024-12-01T12:00:00Z'
+  },
+  'carbon-intensity-service': {
+    name: 'Carbon Intensity',
+    status: 'unhealthy',
+    last_check: '2024-12-01T12:01:00Z',
+    error_message: 'API key missing'
+  }
+};
+
+const createFetchMock = (response: ServicesHealthResponse) =>
+  vi.fn().mockResolvedValue({
+    ok: true,
+    status: 200,
+    statusText: 'OK',
+    json: () => Promise.resolve(response)
+  } as Response);
+
+describe('AdminApiClient service health utilities', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+  });
+
+  it('fetches the services health endpoint directly', async () => {
+    const fetchMock = createFetchMock(mockServicesHealth);
+    vi.stubGlobal('fetch', fetchMock);
+
+    const response = await apiService.getServicesHealth();
+
+    expect(fetchMock).toHaveBeenCalledWith('http://localhost:8003/api/v1/health/services', undefined);
+    expect(response).toEqual(mockServicesHealth);
+  });
+
+  it('maps service health entries into the data sources shape', async () => {
+    const fetchMock = createFetchMock(mockServicesHealth);
+    vi.stubGlobal('fetch', fetchMock);
+
+    const dataSources = await apiService.getAllDataSources();
+
+    expect(dataSources.weather?.status).toBe('healthy');
+    expect(dataSources.weather?.service).toBe('Weather API');
+    expect(dataSources.carbonIntensity?.status).toBe('error');
+    expect(dataSources.carbonIntensity?.error_message).toBe('API key missing');
+    expect(dataSources.airQuality).toBeNull();
+  });
+});

--- a/services/health-dashboard/src/types.ts
+++ b/services/health-dashboard/src/types.ts
@@ -21,7 +21,7 @@ export interface HealthStatus {
 }
 
 export interface DataSourceHealth {
-  status: 'healthy' | 'degraded';
+  status: 'healthy' | 'degraded' | 'error' | 'unknown';
   status_detail?: string;  // 'operational' | 'credentials_missing' | 'degraded' | 'starting'
   service: string;
   uptime_seconds: number;
@@ -32,6 +32,20 @@ export interface DataSourceHealth {
   timestamp: string;
   oauth_valid?: boolean;
   credentials_configured?: boolean;  // For services requiring external API credentials
+  api_usage?: {
+    calls_today: number;
+    quota_limit?: number;
+    quota_percentage?: number;
+  };
+}
+
+export interface DataSourcesHealthMap {
+  weather: DataSourceHealth | null;
+  carbonIntensity: DataSourceHealth | null;
+  electricityPricing: DataSourceHealth | null;
+  airQuality: DataSourceHealth | null;
+  calendar: DataSourceHealth | null;
+  smartMeter: DataSourceHealth | null;
 }
 
 export interface DataSourceMetrics {

--- a/services/health-dashboard/src/types/health.ts
+++ b/services/health-dashboard/src/types/health.ts
@@ -67,6 +67,16 @@ export interface DependencyHealth {
   details?: Record<string, any>;
 }
 
+export interface ServiceHealthStatus {
+  name?: string;
+  status: 'healthy' | 'unhealthy' | 'degraded' | 'unknown' | 'pass' | 'error';
+  last_check?: string;
+  response_time_ms?: number;
+  error_message?: string | null;
+}
+
+export type ServicesHealthResponse = Record<string, ServiceHealthStatus>;
+
 export interface ServiceHealthResponse {
   status: 'healthy' | 'unhealthy' | 'degraded' | 'unknown';
   service: string;


### PR DESCRIPTION
## Summary
- point getServicesHealth uses the /api/v1/health/services endpoint and normalizes the response for the data source cards with reusable types
- point tighten the data source types/UI usage to reflect the normalized structure and ensure safer rendering
- point cover the new normalization logic with a focused vitest suite

## Testing
- npm run test:run

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6917b4657a28832b9af04e1dd12f0265)