### PR TITLE
chore(deps): Phase 1 security and patch updates

### DIFF
--- a/services/admin-api/requirements.txt
+++ b/services/admin-api/requirements.txt
@@ -1,19 +1,19 @@
 # FastAPI and web framework
-fastapi==0.121.0
+fastapi==0.121.2
 uvicorn[standard]==0.38.0
 pydantic==2.8.2
 
 # Authentication and security
-python-jose[cryptography]==3.3.0
+python-jose[cryptography]==3.5.0
 passlib[bcrypt]==1.7.4
 python-multipart==0.0.20
 
 # HTTP client
-aiohttp==3.9.5
-requests==2.32.3
+aiohttp==3.13.2
+requests==2.32.5
 
 # Environment and configuration
-python-dotenv==1.0.1
+python-dotenv==1.2.1
 
 # System monitoring
 psutil==6.0.0
@@ -24,7 +24,7 @@ pytest-asyncio==0.23.0
 httpx==0.27.2
 
 # InfluxDB client
-influxdb-client==1.44.0
+influxdb-client==1.49.0
 
 # Docker management
 docker==6.1.3

--- a/services/ai-automation-service/requirements.txt
+++ b/services/ai-automation-service/requirements.txt
@@ -2,7 +2,7 @@
 # Phase 1 MVP - Keep it simple
 
 # Web Framework
-fastapi==0.121.0
+fastapi==0.121.2
 uvicorn==0.38.0
 python-multipart==0.0.20
 
@@ -11,7 +11,7 @@ pydantic==2.8.2
 pydantic-settings==2.4.0
 
 # Database
-sqlalchemy==2.0.25
+sqlalchemy==2.0.44
 aiosqlite==0.20.0
 alembic==1.13.1
 
@@ -20,10 +20,10 @@ paho-mqtt==1.6.1
 
 # HTTP Client
 httpx==0.27.2
-aiohttp==3.9.5
+aiohttp==3.13.2
 
 # InfluxDB Client
-influxdb-client==1.44.0
+influxdb-client==1.49.0
 
 # Data Processing
 pandas==2.2.3
@@ -53,9 +53,9 @@ peft==0.14.0                  # Lightweight LoRA fine-tuning support
 apscheduler==3.10.4
 
 # Utilities
-python-dotenv==1.0.1
+python-dotenv==1.2.1
 tenacity==8.2.3
-pyyaml==6.0.1
+pyyaml==6.0.3
 deprecated==1.2.14
 rapidfuzz>=3.0.0  # Fast fuzzy string matching for typo handling
 langchain==0.2.14  # Lightweight orchestration for prompt/tool prototypes

--- a/services/ai-core-service/requirements.txt
+++ b/services/ai-core-service/requirements.txt
@@ -2,7 +2,7 @@
 # Phase 1: Containerized AI Models
 
 # Web Framework
-fastapi==0.121.0
+fastapi==0.121.2
 uvicorn[standard]==0.38.0
 
 # Data Validation
@@ -16,7 +16,7 @@ httpx==0.27.2
 tenacity==8.2.3
 
 # Utilities
-python-dotenv==1.0.1
+python-dotenv==1.2.1
 
 # Testing
 pytest==8.3.3

--- a/services/air-quality-service/requirements.txt
+++ b/services/air-quality-service/requirements.txt
@@ -1,4 +1,4 @@
-aiohttp==3.9.5
-python-dotenv==1.0.1
+aiohttp==3.13.2
+python-dotenv==1.2.1
 influxdb3-python==0.3.0
 

--- a/services/calendar-service/requirements.txt
+++ b/services/calendar-service/requirements.txt
@@ -1,4 +1,4 @@
-python-dotenv==1.0.1
+python-dotenv==1.2.1
 influxdb3-python==0.3.0
-aiohttp==3.9.5
+aiohttp==3.13.2
 

--- a/services/carbon-intensity-service/requirements.txt
+++ b/services/carbon-intensity-service/requirements.txt
@@ -1,4 +1,4 @@
-aiohttp==3.9.5
-python-dotenv==1.0.1
+aiohttp==3.13.2
+python-dotenv==1.2.1
 influxdb3-python==0.3.0
 

--- a/services/data-api/requirements.txt
+++ b/services/data-api/requirements.txt
@@ -2,16 +2,16 @@
 # Python 3.11
 
 # Web Framework
-fastapi==0.121.0
+fastapi==0.121.2
 uvicorn[standard]==0.38.0
 python-multipart==0.0.20
 
 # HTTP Client
-aiohttp==3.9.5
+aiohttp==3.13.2
 
 # Database
-influxdb-client==1.44.0
-sqlalchemy==2.0.25
+influxdb-client==1.49.0
+sqlalchemy==2.0.44
 aiosqlite==0.20.0
 alembic==1.13.1
 
@@ -20,10 +20,10 @@ pydantic==2.8.2
 pydantic-settings==2.4.0
 
 # Configuration
-python-dotenv==1.0.1
+python-dotenv==1.2.1
 
 # Utilities
-python-jose[cryptography]==3.3.0
+python-jose[cryptography]==3.5.0
 passlib[bcrypt]==1.7.4
 
 # Testing (development)

--- a/services/device-intelligence-service/requirements.txt
+++ b/services/device-intelligence-service/requirements.txt
@@ -1,7 +1,7 @@
 # Device Intelligence Service Dependencies
 
 # FastAPI and ASGI server
-fastapi==0.121.0
+fastapi==0.121.2
 uvicorn[standard]==0.38.0
 
 # Pydantic for settings and data validation
@@ -9,13 +9,13 @@ pydantic==2.8.2
 pydantic-settings==2.4.0
 
 # Database and ORM
-sqlalchemy==2.0.25
+sqlalchemy==2.0.44
 aiosqlite==0.20.0
 alembic==1.13.1
 
 # HTTP client for external APIs
 httpx==0.27.2
-aiohttp==3.9.5
+aiohttp==3.13.2
 
 # WebSocket client
 websockets==12.0

--- a/services/electricity-pricing-service/requirements.txt
+++ b/services/electricity-pricing-service/requirements.txt
@@ -1,4 +1,4 @@
-aiohttp==3.9.5
-python-dotenv==1.0.1
+aiohttp==3.13.2
+python-dotenv==1.2.1
 influxdb3-python==0.3.0
 

--- a/services/energy-correlator/requirements.txt
+++ b/services/energy-correlator/requirements.txt
@@ -1,4 +1,4 @@
-aiohttp==3.9.5
-influxdb-client==1.44.0
-python-dotenv==1.0.1
+aiohttp==3.13.2
+influxdb-client==1.49.0
+python-dotenv==1.2.1
 

--- a/services/ha-setup-service/requirements.txt
+++ b/services/ha-setup-service/requirements.txt
@@ -1,15 +1,15 @@
 # FastAPI and core dependencies
-fastapi==0.121.0
+fastapi==0.121.2
 uvicorn[standard]==0.38.0
 pydantic==2.8.2
 pydantic-settings==2.4.0
 
 # Async support
-aiohttp==3.9.5
+aiohttp==3.13.2
 aiosqlite==0.20.0
 
 # Database
-sqlalchemy==2.0.25
+sqlalchemy==2.0.44
 alembic==1.13.1
 
 # Testing
@@ -18,5 +18,5 @@ pytest-asyncio==0.23.0
 httpx==0.27.2
 
 # Shared utilities (from parent project)
-python-dotenv==1.0.1
+python-dotenv==1.2.1
 

--- a/services/ha-simulator/requirements.txt
+++ b/services/ha-simulator/requirements.txt
@@ -1,4 +1,4 @@
-aiohttp==3.9.5
+aiohttp==3.13.2
 asyncio-mqtt==0.16.1
 PyYAML==6.0.1
 pytest==8.3.3

--- a/services/log-aggregator/requirements.txt
+++ b/services/log-aggregator/requirements.txt
@@ -1,4 +1,4 @@
-aiohttp==3.9.5
+aiohttp==3.13.2
 aiofiles==23.2.1
 docker==7.1.0
 aiohttp-cors==0.7.0

--- a/services/ml-service/requirements.txt
+++ b/services/ml-service/requirements.txt
@@ -2,7 +2,7 @@
 # Phase 1: Containerized AI Models
 
 # Web Framework
-fastapi==0.121.0
+fastapi==0.121.2
 uvicorn[standard]==0.38.0
 
 # Data Validation
@@ -21,7 +21,7 @@ numpy==1.26.4
 scipy==1.12.0
 
 # Utilities
-python-dotenv==1.0.1
+python-dotenv==1.2.1
 tenacity==8.2.3
 
 # Testing

--- a/services/openvino-service/requirements.txt
+++ b/services/openvino-service/requirements.txt
@@ -2,7 +2,7 @@
 # Phase 1: Containerized AI Models
 
 # Web Framework
-fastapi==0.121.0
+fastapi==0.121.2
 uvicorn[standard]==0.38.0
 
 # Data Validation
@@ -27,7 +27,7 @@ sentencepiece                 # Required for T5 tokenizer
 # Removed OpenVINO for now due to dependency conflicts
 
 # Utilities
-python-dotenv==1.0.1
+python-dotenv==1.2.1
 tenacity==8.2.3
 
 # Testing

--- a/services/smart-meter-service/requirements.txt
+++ b/services/smart-meter-service/requirements.txt
@@ -1,4 +1,4 @@
-aiohttp==3.9.5
-python-dotenv==1.0.1
+aiohttp==3.13.2
+python-dotenv==1.2.1
 influxdb3-python==0.3.0
 

--- a/services/weather-api/requirements.txt
+++ b/services/weather-api/requirements.txt
@@ -1,7 +1,7 @@
-fastapi==0.121.0
+fastapi==0.121.2
 uvicorn[standard]==0.38.0
-aiohttp==3.9.5
-python-dotenv==1.0.1
+aiohttp==3.13.2
+python-dotenv==1.2.1
 pydantic==2.8.2
 influxdb3-python[pandas]==0.3.0
 pytest==8.3.3

--- a/services/websocket-ingestion/requirements.txt
+++ b/services/websocket-ingestion/requirements.txt
@@ -1,6 +1,6 @@
-aiohttp==3.9.5
+aiohttp==3.13.2
 asyncio-mqtt==0.16.1
-python-dotenv==1.0.1
+python-dotenv==1.2.1
 pydantic==2.8.2
 psutil==6.0.0
 pytest==8.3.3


### PR DESCRIPTION
Apply Phase 1 dependency updates as per DEPENDENCY_UPGRADE_REPORT.md. These are low-risk security patches and bug fixes with no breaking changes.

Updates applied across 18 services:

Security & Core Updates:
- fastapi: 0.121.0 → 0.121.2 (9 services)
- aiohttp: 3.9.5 → 3.13.2 (15 services) - security fixes
- pyyaml: 6.0.1 → 6.0.3 (1 service) - security fixes
- python-jose: 3.3.0 → 3.5.0 (2 services) - security related
- sqlalchemy: 2.0.25 → 2.0.44 (4 services) - 19 versions of bug fixes
- influxdb-client: 1.44.0 → 1.49.0 (4 services)
- requests: 2.32.3 → 2.32.5 (1 service)
- python-dotenv: 1.0.1 → 1.2.1 (15 services)

Affected services:
- admin-api
- ai-automation-service
- ai-core-service
- air-quality-service
- calendar-service
- carbon-intensity-service
- data-api
- device-intelligence-service
- electricity-pricing-service
- energy-correlator
- ha-setup-service
- ha-simulator
- log-aggregator
- ml-service
- openvino-service
- smart-meter-service
- weather-api
- websocket-ingestion

Testing: Minimal risk - patch and minor updates only. No breaking changes.

Related: DEPENDENCY_UPGRADE_REPORT.md Phase 1