### PR TITLE
Fix NL generator device intelligence configuration

### DIFF
--- a/services/ai-automation-service/src/nl_automation_generator.py
+++ b/services/ai-automation-service/src/nl_automation_generator.py
@@ -16,6 +16,7 @@ from .clients.data_api_client import DataAPIClient
 from .clients.device_intelligence_client import DeviceIntelligenceClient
 from .llm.openai_client import OpenAIClient
 from .safety_validator import SafetyValidator, SafetyResult
+from .config import settings
 
 logger = logging.getLogger(__name__)
 
@@ -656,7 +657,8 @@ Generate a valid automation now (JSON only):"""
 def get_nl_generator(
     data_api_client: DataAPIClient,
     openai_client: OpenAIClient,
-    safety_validator: SafetyValidator
+    safety_validator: SafetyValidator,
+    device_intelligence_client: Optional[DeviceIntelligenceClient] = None
 ) -> NLAutomationGenerator:
     """
     Factory function to create NL automation generator.
@@ -669,9 +671,15 @@ def get_nl_generator(
     Returns:
         Configured NLAutomationGenerator
     """
+    if device_intelligence_client is None and getattr(settings, "device_intelligence_enabled", True):
+        device_intelligence_client = DeviceIntelligenceClient(
+            base_url=getattr(settings, "device_intelligence_url", "http://device-intelligence-service:8021")
+        )
+
     return NLAutomationGenerator(
         data_api_client=data_api_client,
         openai_client=openai_client,
-        safety_validator=safety_validator
+        safety_validator=safety_validator,
+        device_intelligence_client=device_intelligence_client
     )
 

--- a/services/ai-automation-service/tests/test_nl_generator.py
+++ b/services/ai-automation-service/tests/test_nl_generator.py
@@ -16,6 +16,7 @@ from src.nl_automation_generator import (
     get_nl_generator
 )
 from src.safety_validator import SafetyValidator, SafetyLevel, SafetyResult, SafetyIssue
+from src.config import settings
 
 
 class TestNLAutomationGenerator:
@@ -338,12 +339,14 @@ class TestGetNLGenerator:
             openai_client=mock_openai_client,
             safety_validator=mock_safety_validator
         )
-        
+
         assert generator is not None
         assert isinstance(generator, NLAutomationGenerator)
         assert generator.data_api_client == mock_data_api_client
         assert generator.openai_client == mock_openai_client
         assert generator.safety_validator == mock_safety_validator
+        assert generator.device_intelligence_client is not None
+        assert generator.device_intelligence_client.base_url == settings.device_intelligence_url
 
 
 # Shared Fixtures


### PR DESCRIPTION
## Summary
- ensure the NL automation generator factory injects a DeviceIntelligenceClient configured with the service URL from settings so Team Tracker data can be retrieved
- expand the NL generator factory test to cover the configured client to prevent regressions

## Testing
- `pytest services/ai-automation-service/tests/test_nl_generator.py` *(fails: missing HA_URL, HA_TOKEN, MQTT_BROKER, OPENAI_API_KEY test environment variables)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6917cab4afd0832bad85018ce373a619)