### PR TITLE
Hardening websocket ingestion reliability

### DIFF
--- a/issues/closed/001-websocket-ingestion-critical-issues.md
+++ b/issues/closed/001-websocket-ingestion-critical-issues.md
@@ -1,9 +1,11 @@
 ---
-status: Open
+status: Closed
 priority: Critical
 service: websocket-ingestion
 created: 2025-11-15
 labels: [critical, reliability, security, performance]
+closed: 2025-02-15
+resolution: Completed
 ---
 
 # [CRITICAL] WebSocket Ingestion Service - Multiple Critical Issues
@@ -11,7 +13,15 @@ labels: [critical, reliability, security, performance]
 **Use 2025 patterns, architecture and versions for decisions and ensure the Readme files are up to date.**
 
 ## Overview
-Analysis of the websocket-ingestion service has identified **6 CRITICAL issues** that require immediate attention to prevent service crashes, data loss, and resource exhaustion.
+Analysis of the websocket-ingestion service has identified **6 CRITICAL issues** that required immediate attention to prevent service crashes, data loss, and resource exhaustion.
+
+## Resolution Summary (2025-02-15)
+- ✅ Entity deletions now keep `new_state` optional-safe within `event_processor.py`, preventing AttributeErrors and preserving state diffs.
+- ✅ `influxdb-client` dependency is included in both development and production requirement manifests to avoid import/runtime failures.
+- ✅ `HomeAssistantWebSocketClient` enforces a single `aiohttp.ClientSession`, closing stale sessions before reconnects to eliminate descriptor leaks.
+- ✅ `BatchProcessor` drains batches before invoking handlers, so the lock is never held while handlers run; regression tests cover the scenario.
+- ✅ `InfluxDBBatchWriter` gained bounded queues + overflow strategies plus env-tunable limits, delivering deterministic backpressure when InfluxDB is degraded.
+- ✅ The shared module path in `main.py` is now environment-driven, so deployments without `/app/shared` boot successfully.
 
 ---
 

--- a/services/websocket-ingestion/README.md
+++ b/services/websocket-ingestion/README.md
@@ -25,6 +25,8 @@ The WebSocket Ingestion Service connects to Home Assistant's WebSocket API to ca
 - 🎯 **Epic 23 Enhancements** - Context tracking, spatial analytics, duration tracking
 - ⚡ **High Performance** - 10,000+ events/second throughput capability
 - 🛡️ **Circuit Breaker** - Prevents cascading failures during outages
+- 🧰 **Shared Module Auto-Discovery** - Override shared path via `HOMEIQ_SHARED_PATH`
+- 🧊 **Backpressure-Protected Influx Writes** - Configurable queue + overflow strategies stop runaway memory usage
 
 ## Network Resilience
 
@@ -180,7 +182,6 @@ INFLUXDB_URL=http://influxdb:8086
 INFLUXDB_TOKEN=your-influxdb-token
 INFLUXDB_ORG=homeiq
 INFLUXDB_BUCKET=home_assistant_events
-
 # Network Resilience (Defaults shown)
 WEBSOCKET_MAX_RETRIES=-1  # Infinite retry
 WEBSOCKET_MAX_RETRY_DELAY=300  # 5 minutes max delay
@@ -191,6 +192,9 @@ WEBSOCKET_MAX_RETRY_DELAY=300  # 5 minutes max delay
 ```bash
 # Device Discovery Storage
 STORE_DEVICE_HISTORY_IN_INFLUXDB=false  # Optional InfluxDB history
+
+# Shared module import override (defaults to repo ./shared directory)
+HOMEIQ_SHARED_PATH=/app/shared
 
 # Weather Enrichment (DEPRECATED - Use weather-api service)
 WEATHER_API_KEY=your_openweathermap_api_key
@@ -209,6 +213,10 @@ LOG_OUTPUT=both
 
 # Performance
 MAX_MEMORY_MB=500  # Memory limit before alerts
+
+# InfluxDB write queue controls
+INFLUXDB_MAX_PENDING_POINTS=20000
+INFLUXDB_OVERFLOW_STRATEGY=drop_oldest  # drop_oldest | drop_new
 ```
 
 ## API Endpoints

--- a/services/websocket-ingestion/requirements-prod.txt
+++ b/services/websocket-ingestion/requirements-prod.txt
@@ -3,5 +3,5 @@ asyncio-mqtt==0.16.1
 python-dotenv==1.0.1
 pydantic==2.8.2
 psutil==6.0.0
-influxdb-client==1.44.0
+influxdb-client==1.48.0
 websockets==12.0

--- a/services/websocket-ingestion/requirements.txt
+++ b/services/websocket-ingestion/requirements.txt
@@ -3,5 +3,6 @@ asyncio-mqtt==0.16.1
 python-dotenv==1.2.1
 pydantic==2.12.4
 psutil==7.1.3
+influxdb-client==1.48.0
 pytest==8.3.3
 pytest-asyncio==0.23.0

--- a/services/websocket-ingestion/tests/test_event_processor.py
+++ b/services/websocket-ingestion/tests/test_event_processor.py
@@ -109,7 +109,22 @@ class TestEventProcessor:
         assert extracted["state_change"]["from"] == "off"
         assert extracted["state_change"]["to"] == "on"
         assert extracted["state_change"]["changed"] is True
-    
+
+    def test_extract_event_data_handles_deleted_entity(self):
+        """Ensure entity deletions with null new_state don't crash"""
+        event_data = {
+            "event_type": "state_changed",
+            "old_state": {"state": "on", "entity_id": "sensor.kitchen_motion"},
+            "new_state": None
+        }
+
+        extracted = self.processor.extract_event_data(event_data)
+
+        assert extracted["entity_id"] == "sensor.kitchen_motion"
+        assert extracted["state_change"]["from"] == "on"
+        assert extracted["state_change"]["to"] is None
+        assert extracted["state_change"]["changed"] is True
+
     def test_extract_event_data_call_service(self):
         """Test extracting data from call_service event"""
         event_data = {

--- a/services/websocket-ingestion/tests/test_influxdb_batch_writer.py
+++ b/services/websocket-ingestion/tests/test_influxdb_batch_writer.py
@@ -1,0 +1,69 @@
+import asyncio
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+
+from influxdb_batch_writer import InfluxDBBatchWriter
+
+
+@pytest.fixture
+def writer(monkeypatch):
+    schema = SimpleNamespace()
+    schema.create_event_point = lambda event: {"id": event["id"]}
+    schema.create_weather_point = lambda weather, location: {"loc": location, **weather}
+    schema.validate_point = lambda point: (True, [])
+
+    monkeypatch.setattr("influxdb_batch_writer.InfluxDBSchema", lambda: schema)
+
+    manager = AsyncMock()
+    manager.write_points = AsyncMock(return_value=True)
+
+    batch_writer = InfluxDBBatchWriter(
+        connection_manager=manager,
+        batch_size=100,
+        batch_timeout=0.1,
+        max_pending_points=3,
+        overflow_strategy="drop_oldest",
+    )
+
+    return batch_writer, manager
+
+
+@pytest.mark.asyncio
+async def test_backpressure_drops_oldest(writer):
+    batch_writer, _ = writer
+
+    for idx in range(4):
+        assert await batch_writer.write_event({"id": idx})
+
+    assert len(batch_writer.current_batch) == 3
+    assert batch_writer.dropped_points == 1
+    assert batch_writer.queue_overflow_events == 1
+
+
+@pytest.mark.asyncio
+async def test_drop_new_strategy_rejects_point(monkeypatch):
+    schema = SimpleNamespace()
+    schema.create_event_point = lambda event: event
+    schema.create_weather_point = lambda weather, location: weather
+    schema.validate_point = lambda point: (True, [])
+
+    monkeypatch.setattr("influxdb_batch_writer.InfluxDBSchema", lambda: schema)
+
+    manager = AsyncMock()
+    manager.write_points = AsyncMock(return_value=True)
+
+    batch_writer = InfluxDBBatchWriter(
+        connection_manager=manager,
+        batch_size=100,
+        max_pending_points=1,
+        overflow_strategy="drop_new",
+    )
+
+    assert await batch_writer.write_event({"id": 1})
+    result = await batch_writer.write_event({"id": 2})
+
+    assert result is False
+    assert batch_writer.dropped_points == 1
+    assert batch_writer.queue_overflow_events == 1


### PR DESCRIPTION
## Summary
- guard event processing against deleted-entity payloads and add regression coverage
- eliminate websocket ClientSession leaks, decouple batch locks from handler execution, and add bounded InfluxDB backpressure with configuration + docs
- document and close the websocket-ingestion issue by moving it into the closed folder

## Testing
- `pytest services/websocket-ingestion/tests/test_event_processor.py services/websocket-ingestion/tests/test_batch_processor.py services/websocket-ingestion/tests/test_influxdb_batch_writer.py`


------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6918f51e97d4832baaff9dc0a7bd7f45)