### PR TITLE
docs: Comprehensive documentation update - service READMEs and port mapping reference

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -433,6 +433,11 @@ git push origin feature/amazing-feature
 - **USE:** [docs/api/API_REFERENCE.md](docs/api/API_REFERENCE.md) - All 65 endpoints
 - **IGNORE:** All other API_*.md files (marked with redirect notices)
 
+**Port Mapping:**
+- **USE:** [docs/PORT_MAPPING_REFERENCE.md](docs/PORT_MAPPING_REFERENCE.md) - All service port mappings (internal vs external)
+- **KEY INFO:** Docker port conflicts resolved via external:internal mapping (e.g., 8024:8018)
+- **CRITICAL:** Always use external ports for production access, internal ports for local dev
+
 **Architecture:**
 - **USE:** [docs/architecture/](docs/architecture/) - 27 current docs
 - **KEY FILES:**
@@ -450,6 +455,7 @@ git push origin feature/amazing-feature
 | Need | Location |
 |------|----------|
 | API endpoints | docs/api/API_REFERENCE.md |
+| Port mappings | docs/PORT_MAPPING_REFERENCE.md |
 | Architecture | docs/architecture/ |
 | Deployment | docs/DEPLOYMENT_GUIDE.md |
 | Quick start | docs/QUICK_START.md |
@@ -836,8 +842,13 @@ docker compose logs websocket-ingestion
 
 **Document Metadata:**
 - **Created:** October 23, 2025
-- **Last Updated:** December 08, 2025
-- **Version:** 5.0.0 (Comprehensive guide - includes structure, workflows, patterns)
-- **Previous Version:** 4.0.0 (Performance patterns only)
+- **Last Updated:** December 09, 2025
+- **Version:** 5.0.1 (Added PORT_MAPPING_REFERENCE.md documentation)
+- **Previous Version:** 5.0.0 (Comprehensive guide - includes structure, workflows, patterns)
 - **Next Review:** Quarterly or after major architectural changes
 - **Maintainer:** HomeIQ Development Team
+
+**Change Log v5.0.1:**
+- Added PORT_MAPPING_REFERENCE.md to documentation structure
+- Clarified external vs internal port usage for Docker services
+- Updated "Finding Documentation" table with port mapping reference

--- a/docs/PORT_MAPPING_REFERENCE.md
+++ b/docs/PORT_MAPPING_REFERENCE.md
@@ -1,0 +1,336 @@
+# HomeIQ Port Mapping Reference
+
+**Last Updated:** December 09, 2025
+**Version:** 1.0.0
+**Purpose:** Comprehensive reference for all HomeIQ service port mappings
+
+---
+
+## Overview
+
+HomeIQ uses Docker Compose to manage 24 active microservices on a single NUC deployment. Due to port conflicts where multiple services share the same internal port, Docker Compose maps external ports to internal container ports.
+
+**Port Mapping Format:** `EXTERNAL:INTERNAL` (e.g., `8024:8018` means external port 8024 maps to internal port 8018)
+
+**Why Port Mapping?**
+- Multiple services use the same internal ports (8018, 8019, 8020)
+- Docker resolves conflicts by exposing different external ports
+- Services communicate internally using container names (not ports)
+- External clients access services via mapped external ports
+
+---
+
+## Complete Service Port Reference
+
+### Web Layer (Frontend Services)
+
+| Service | External Port | Internal Port | Container Name | Access URL |
+|---------|--------------|---------------|----------------|------------|
+| **Health Dashboard** | 3000 | 80 | homeiq-health-dashboard | http://localhost:3000 |
+| **AI Automation UI** | 3001 | 80 | homeiq-ai-automation-ui | http://localhost:3001 |
+
+---
+
+### Core API Layer
+
+| Service | External Port | Internal Port | Container Name | Access URL |
+|---------|--------------|---------------|----------------|------------|
+| **WebSocket Ingestion** | 8001 | 8001 | homeiq-websocket | http://localhost:8001 |
+| **Admin API** | 8003 | 8004 | homeiq-admin-api | http://localhost:8003 |
+| **Data API** | 8006 | 8006 | homeiq-data-api | http://localhost:8006 |
+
+---
+
+### AI Services Layer
+
+| Service | External Port | Internal Port | Port Conflict | Container Name | Access URL |
+|---------|--------------|---------------|---------------|----------------|------------|
+| **AI Core Service** | 8018 | 8018 | ✅ Original | homeiq-ai-core | http://localhost:8018 |
+| **AI Automation Service** | 8024 | 8018 | ⚠️ Conflicts with AI Core | homeiq-ai-automation-service | http://localhost:8024 |
+| **AI Query Service** | 8035 | 8018 | ⚠️ Conflicts with AI Core | homeiq-ai-query-service | http://localhost:8035 |
+| **OpenVINO Service** | 8026 | 8019 | ⚠️ Conflicts with Device Intelligence | homeiq-openvino-service | http://localhost:8026 |
+| **Device Intelligence** | 8028 | 8019 | ⚠️ Conflicts with OpenVINO | homeiq-device-intelligence | http://localhost:8028 |
+| **Automation Miner** | 8029 | 8019 | ⚠️ Conflicts with OpenVINO | homeiq-automation-miner | http://localhost:8029 |
+| **OpenAI Service** | 8020 | 8020 | ✅ Original | homeiq-openai-service | http://localhost:8020 |
+| **ML Service** | 8025 | 8020 | ⚠️ Conflicts with OpenAI | homeiq-ml-service | http://localhost:8025 |
+| **HA Setup Service** | 8027 | 8020 | ⚠️ Conflicts with OpenAI | homeiq-ha-setup-service | http://localhost:8027 |
+| **AI Pattern Service** | 8034 | 8020 | ⚠️ Conflicts with OpenAI | homeiq-ai-pattern-service | http://localhost:8034 |
+| **NER Service** | 8031 (exposed) | 8031 | ✅ Internal only | homeiq-ner-service | Internal only |
+| **Proactive Agent** | 8031 (exposed) | 8031 | ✅ Internal only | homeiq-proactive-agent | Internal only |
+
+---
+
+### Data Enrichment Layer (Epic 31: Direct InfluxDB Writes)
+
+| Service | External Port | Internal Port | Container Name | Access URL |
+|---------|--------------|---------------|----------------|------------|
+| **Weather API** | 8009 | 8009 | homeiq-weather-api | http://localhost:8009 |
+| **Carbon Intensity** | 8010 | 8010 | homeiq-carbon-intensity | http://localhost:8010 |
+| **Electricity Pricing** | 8011 | 8011 | homeiq-electricity-pricing | http://localhost:8011 |
+| **Air Quality** | 8012 | 8012 | homeiq-air-quality | http://localhost:8012 |
+| **Calendar Service** | 8013 | 8013 | homeiq-calendar | ⏸️ Currently disabled |
+| **Smart Meter** | 8014 | 8014 | homeiq-smart-meter | http://localhost:8014 |
+
+---
+
+### Processing & Infrastructure Layer
+
+| Service | External Port | Internal Port | Container Name | Access URL |
+|---------|--------------|---------------|----------------|------------|
+| **Log Aggregator** | 8015 | 8015 | homeiq-log-aggregator | http://localhost:8015 |
+| **Energy Correlator** | 8017 | 8017 | homeiq-energy-correlator | http://localhost:8017 |
+| **Data Retention** | 8080 | 8080 | homeiq-data-retention | http://localhost:8080 |
+
+---
+
+### Infrastructure Services (Not HomeIQ)
+
+| Service | Port | Container Name | Access URL |
+|---------|------|----------------|------------|
+| **InfluxDB** | 8086 | homeiq-influxdb | http://localhost:8086 |
+| **Home Assistant** | 8123 | N/A (external) | http://192.168.1.86:8123 |
+| **MQTT Broker** | 1883 | N/A (external) | mqtt://192.168.1.86:1883 |
+
+---
+
+## Port Conflict Resolution
+
+### Internal Port 8018 Conflicts
+
+**Services sharing port 8018:**
+1. AI Core Service: `8018:8018` ✅ Original
+2. AI Automation Service: `8024:8018` ⚠️ Remapped
+3. AI Query Service: `8035:8018` ⚠️ Remapped
+
+**Resolution:**
+- AI Core Service keeps original port 8018
+- AI Automation Service exposed as 8024 externally
+- AI Query Service exposed as 8035 externally
+
+### Internal Port 8019 Conflicts
+
+**Services sharing port 8019:**
+1. OpenVINO Service: `8026:8019` ⚠️ Remapped
+2. Device Intelligence: `8028:8019` ⚠️ Remapped
+3. Automation Miner: `8029:8019` ⚠️ Remapped
+
+**Resolution:**
+- All three services remapped to different external ports
+- Services communicate internally via container names
+
+### Internal Port 8020 Conflicts
+
+**Services sharing port 8020:**
+1. OpenAI Service: `8020:8020` ✅ Original
+2. ML Service: `8025:8020` ⚠️ Remapped
+3. HA Setup Service: `8027:8020` ⚠️ Remapped
+4. AI Pattern Service: `8034:8020` ⚠️ Remapped
+
+**Resolution:**
+- OpenAI Service keeps original port 8020
+- Other services exposed on different external ports
+
+---
+
+## Port Range Allocation
+
+### Reserved Ranges
+
+- **3000-3999:** Frontend services (React UIs)
+- **8001-8099:** Backend services (APIs, processors, AI)
+- **8000s:** Core APIs (websocket, admin, data)
+- **8010s:** Enrichment services (weather, carbon, etc.)
+- **8020s-8030s:** AI services (ML, OpenVINO, automation)
+
+### Available Ports (for future services)
+
+- 8002 (available)
+- 8005 (available)
+- 8007-8008 (available)
+- 8016 (available)
+- 8021-8023 (available)
+- 8030 (available)
+- 8032-8033 (available)
+- 8036+ (available)
+
+---
+
+## Service-to-Service Communication
+
+**Internal Docker Network:** `homeiq-network`
+
+Services communicate using **container names**, not ports:
+```python
+# Good: Use container name (DNS resolution within Docker network)
+DATA_API_URL = "http://data-api:8006"
+AI_CORE_URL = "http://ai-core-service:8018"
+
+# Bad: Use localhost (doesn't work inside containers)
+DATA_API_URL = "http://localhost:8006"  # ❌ Won't work
+```
+
+**Example:** AI Automation Service calls Device Intelligence:
+```python
+# Inside ai-automation-service container
+import httpx
+response = await httpx.get("http://device-intelligence-service:8019/api/devices")
+# Uses internal port 8019, not external port 8028
+```
+
+---
+
+## Local Development Port Usage
+
+When developing locally **without Docker**, use the **internal port**:
+
+```bash
+# ML Service local development
+cd services/ml-service
+uvicorn src.main:app --reload --port 8020  # Internal port
+
+# Access locally
+curl http://localhost:8020/health
+
+# In Docker production
+curl http://localhost:8025/health  # External port
+```
+
+**General Rule:**
+- **Local development:** Use internal port
+- **Docker production:** Use external port
+- **Service-to-service:** Use container name + internal port
+
+---
+
+## docker-compose.yml Port Mapping Examples
+
+### Simple Port Mapping (No Conflict)
+
+```yaml
+websocket-ingestion:
+  ports:
+    - "8001:8001"  # external:internal
+  # Both ports are the same (no conflict)
+```
+
+### Port Conflict Resolution
+
+```yaml
+ai-automation-service:
+  ports:
+    - "8024:8018"  # external:internal
+  # External 8024 maps to internal 8018
+  # Resolves conflict with ai-core-service (8018:8018)
+```
+
+### Exposed But Not Published (Internal Only)
+
+```yaml
+ner-service:
+  expose:
+    - "8031"  # Accessible within Docker network only
+  # No external port mapping
+  # Only accessible by other containers
+```
+
+---
+
+## Troubleshooting
+
+### Issue: "Connection refused" when accessing service
+
+**Cause:** Using wrong port (internal vs external)
+
+**Solution:**
+```bash
+# If accessing from host machine, use external port
+curl http://localhost:8025/health  # ✅ ML Service external
+
+# If accessing from another container, use container name + internal port
+curl http://ml-service:8020/health  # ✅ ML Service internal
+```
+
+### Issue: "Port already in use" when starting Docker Compose
+
+**Cause:** External port conflict with another service on host
+
+**Solution:**
+1. Check what's using the port: `sudo lsof -i :8024`
+2. Stop conflicting service or change port in docker-compose.yml
+3. Restart: `docker compose up -d`
+
+### Issue: Service can't reach another service
+
+**Cause:** Using localhost instead of container name
+
+**Solution:**
+```python
+# Wrong (doesn't work in Docker)
+url = "http://localhost:8020/health"
+
+# Right (works in Docker)
+url = "http://ml-service:8020/health"
+```
+
+---
+
+## Quick Reference Table (Alphabetical)
+
+| Service | External → Internal | Container Name |
+|---------|---------------------|----------------|
+| Admin API | 8003 → 8004 | homeiq-admin-api |
+| AI Automation Service | 8024 → 8018 | homeiq-ai-automation-service |
+| AI Automation UI | 3001 → 80 | homeiq-ai-automation-ui |
+| AI Core Service | 8018 → 8018 | homeiq-ai-core |
+| AI Pattern Service | 8034 → 8020 | homeiq-ai-pattern-service |
+| AI Query Service | 8035 → 8018 | homeiq-ai-query-service |
+| Air Quality | 8012 → 8012 | homeiq-air-quality |
+| Automation Miner | 8029 → 8019 | homeiq-automation-miner |
+| Calendar Service | 8013 → 8013 (disabled) | homeiq-calendar |
+| Carbon Intensity | 8010 → 8010 | homeiq-carbon-intensity |
+| Data API | 8006 → 8006 | homeiq-data-api |
+| Data Retention | 8080 → 8080 | homeiq-data-retention |
+| Device Intelligence | 8028 → 8019 | homeiq-device-intelligence |
+| Electricity Pricing | 8011 → 8011 | homeiq-electricity-pricing |
+| Energy Correlator | 8017 → 8017 | homeiq-energy-correlator |
+| HA Setup Service | 8027 → 8020 | homeiq-ha-setup-service |
+| Health Dashboard | 3000 → 80 | homeiq-health-dashboard |
+| InfluxDB | 8086 → 8086 | homeiq-influxdb |
+| Log Aggregator | 8015 → 8015 | homeiq-log-aggregator |
+| ML Service | 8025 → 8020 | homeiq-ml-service |
+| NER Service | Exposed 8031 (internal) | homeiq-ner-service |
+| OpenAI Service | 8020 → 8020 | homeiq-openai-service |
+| OpenVINO Service | 8026 → 8019 | homeiq-openvino-service |
+| Proactive Agent | Exposed 8031 (internal) | homeiq-proactive-agent |
+| Smart Meter | 8014 → 8014 | homeiq-smart-meter |
+| Weather API | 8009 → 8009 | homeiq-weather-api |
+| WebSocket Ingestion | 8001 → 8001 | homeiq-websocket |
+
+---
+
+## Related Documentation
+
+- [CLAUDE.md](../CLAUDE.md) - Comprehensive guide for AI assistants
+- [API_REFERENCE.md](api/API_REFERENCE.md) - All 65 API endpoints
+- [DEPLOYMENT_GUIDE.md](DEPLOYMENT_GUIDE.md) - Production deployment instructions
+- [docker-compose.yml](../docker-compose.yml) - Service definitions with port mappings
+
+---
+
+## Version History
+
+### v1.0.0 (December 09, 2025)
+- Initial port mapping reference document
+- Documented all 24+ active services
+- Identified and documented port conflicts
+- Added troubleshooting guide
+- Created quick reference table
+
+---
+
+**Document Metadata:**
+- **Created:** December 09, 2025
+- **Last Updated:** December 09, 2025
+- **Version:** 1.0.0
+- **Maintainer:** HomeIQ Development Team
+- **Review Schedule:** Update when services are added/removed or ports change

--- a/services/ai-pattern-service/README.md
+++ b/services/ai-pattern-service/README.md
@@ -1,0 +1,269 @@
+# AI Pattern Service
+
+**Pattern detection, synergy analysis, and community patterns service for HomeIQ**
+
+**Port:** 8020 (internal), exposed as 8034 (external)
+**Technology:** Python 3.11+, FastAPI, SQLAlchemy
+**Container:** homeiq-ai-pattern-service
+**Database:** SQLite (ai_automation.db)
+**Scale:** Optimized for ~50-100 devices (single-home)
+
+## Overview
+
+The AI Pattern Service is a microservice extracted from ai-automation-service (Epic 39, Story 39.5) for independent scaling and maintainability. It handles pattern detection, synergy analysis, and community pattern mining operations that run on a scheduled basis.
+
+**Port Mapping Note:** This service runs on port 8020 internally within the Docker network, but is exposed as port 8034 externally for host access. When making requests from outside Docker, use port 8034. Internal services should use port 8020.
+
+### Key Features
+
+- **Scheduled Pattern Analysis** - Automated pattern detection running on configurable cron schedule (default: 3 AM daily)
+- **Time-of-Day Pattern Detection** - Identifies recurring automation patterns based on time
+- **Co-occurrence Pattern Detection** - Discovers devices that are frequently used together
+- **Synergy Detection** - Multi-hop device relationship discovery with confidence scoring
+- **Community Pattern Mining** - Integration with automation-miner service for community insights
+- **MQTT Notifications** - Optional notifications for pattern detection events
+- **Incremental Updates** - Enable/disable incremental pattern analysis
+- **Observability** - OpenTelemetry tracing, correlation middleware, structured logging
+
+## API Endpoints
+
+### Health Endpoints
+
+```bash
+GET /health
+```
+Health check with database connectivity verification.
+
+**Response:**
+```json
+{
+  "status": "ok",
+  "database": "connected"
+}
+```
+
+```bash
+GET /ready
+```
+Kubernetes readiness probe endpoint.
+
+**Response:**
+```json
+{
+  "status": "ready"
+}
+```
+
+```bash
+GET /live
+```
+Kubernetes liveness probe endpoint.
+
+**Response:**
+```json
+{
+  "status": "live"
+}
+```
+
+### Service Info
+
+```bash
+GET /
+```
+Root endpoint with service information.
+
+**Response:**
+```json
+{
+  "service": "ai-pattern-service",
+  "version": "1.0.0",
+  "status": "operational"
+}
+```
+
+## Configuration
+
+### Environment Variables
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `DATABASE_PATH` | `/app/data/ai_automation.db` | Path to SQLite database file |
+| `DATABASE_URL` | `sqlite+aiosqlite:////app/data/ai_automation.db` | SQLAlchemy database URL |
+| `DATABASE_POOL_SIZE` | `10` | Database connection pool size (max 20 per service) |
+| `DATABASE_MAX_OVERFLOW` | `5` | Max overflow connections |
+| `DATA_API_URL` | `http://data-api:8006` | Data API service URL |
+| `SERVICE_PORT` | `8020` | Internal service port |
+| `SERVICE_NAME` | `ai-pattern-service` | Service name for logging/tracing |
+| `LOG_LEVEL` | `INFO` | Logging level (DEBUG, INFO, WARNING, ERROR) |
+| `CORS_ORIGINS` | `http://localhost:3000,http://localhost:3001` | Allowed CORS origins |
+
+#### Pattern Detection Configuration
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `SYNERGY_MIN_CONFIDENCE` | `0.5` | Minimum confidence score for synergy detection |
+| `SYNERGY_MIN_IMPACT_SCORE` | `0.3` | Minimum impact score for synergy detection |
+| `TIME_OF_DAY_OCCURRENCE_OVERRIDES` | `{}` | Override occurrence thresholds (JSON dict) |
+| `TIME_OF_DAY_CONFIDENCE_OVERRIDES` | `{}` | Override confidence thresholds (JSON dict) |
+| `CO_OCCURRENCE_SUPPORT_OVERRIDES` | `{}` | Override support thresholds (JSON dict) |
+| `CO_OCCURRENCE_CONFIDENCE_OVERRIDES` | `{}` | Override confidence thresholds (JSON dict) |
+
+#### Scheduler Configuration (Story 39.6)
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `ANALYSIS_SCHEDULE` | `0 3 * * *` | Cron schedule for pattern analysis (default: 3 AM daily) |
+| `ENABLE_INCREMENTAL` | `True` | Enable incremental pattern updates |
+
+#### MQTT Configuration (Story 39.6)
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `MQTT_BROKER` | `None` | MQTT broker hostname (e.g., `192.168.1.86`) |
+| `MQTT_PORT` | `1883` | MQTT broker port |
+| `MQTT_USERNAME` | `None` | MQTT username (optional) |
+| `MQTT_PASSWORD` | `None` | MQTT password (optional) |
+
+## Development
+
+### Running Locally
+
+```bash
+cd services/ai-pattern-service
+python -m venv venv
+source venv/bin/activate  # On Windows: venv\Scripts\activate
+pip install -r requirements.txt
+uvicorn src.main:app --reload --port 8020
+```
+
+### Running with Docker
+
+```bash
+# Build and start service
+docker compose up -d ai-pattern-service
+
+# View logs
+docker compose logs -f ai-pattern-service
+
+# Test health endpoint (external port)
+curl http://localhost:8034/health
+
+# Test from inside Docker network (internal port)
+docker exec homeiq-ai-automation-ui curl http://ai-pattern-service:8020/health
+```
+
+### Testing Endpoints
+
+```bash
+# Health check
+curl http://localhost:8034/health
+
+# Readiness check
+curl http://localhost:8034/ready
+
+# Liveness check
+curl http://localhost:8034/live
+
+# Service info
+curl http://localhost:8034/
+```
+
+## Dependencies
+
+### Service Dependencies
+
+- **data-api** (Port 8006) - Historical data queries, device/entity metadata
+- **SQLite Database** - Shared ai_automation.db for pattern storage
+- **MQTT Broker** (Optional) - Pattern detection notifications (typically Home Assistant's MQTT at 192.168.1.86:1883)
+
+### Python Dependencies
+
+- `fastapi` - Web framework
+- `uvicorn` - ASGI server
+- `sqlalchemy` - Database ORM
+- `aiosqlite` - Async SQLite driver
+- `pydantic` - Configuration management
+- `pydantic-settings` - Environment variable loading
+- `shared` - HomeIQ shared libraries (logging, observability, error handling)
+
+## Related Services
+
+### Upstream Dependencies
+
+- **data-api** - Provides historical event data for pattern analysis
+- **automation-miner** - Community pattern corpus (optional)
+
+### Downstream Consumers
+
+- **ai-automation-service** - Uses detected patterns for automation generation
+- **ai-automation-ui** - Displays pattern insights to users
+- **health-dashboard** - Monitors pattern service health
+
+## Architecture Notes
+
+### Separation from AI Automation Service
+
+This service was extracted from ai-automation-service in Epic 39, Story 39.5 to:
+- Enable independent scaling of pattern detection workloads
+- Isolate long-running batch operations from real-time query handling
+- Improve maintainability and deployment flexibility
+- Support nightly analysis without impacting interactive performance
+
+### Scheduled Analysis
+
+The service runs pattern analysis on a configurable cron schedule (default: 3 AM daily):
+1. **Pattern Detection** - Time-of-day and co-occurrence patterns
+2. **Synergy Analysis** - Multi-hop device relationships
+3. **Community Patterns** - Integration with automation-miner
+4. **MQTT Notifications** - Optional alerts for new patterns
+
+### Database Sharing
+
+This service shares the `ai_automation.db` SQLite database with ai-automation-service:
+- **Pattern Storage** - Detected patterns, synergy relationships
+- **Community Patterns** - Mined automation patterns
+- **Configuration** - Pattern detection thresholds and overrides
+
+## Monitoring
+
+### Health Checks
+
+- **Liveness:** `GET /live` - Service is running
+- **Readiness:** `GET /ready` - Service is ready to accept traffic
+- **Health:** `GET /health` - Database connectivity verified
+
+### Logging
+
+All logs follow structured logging format with correlation IDs:
+```json
+{
+  "timestamp": "2025-12-09T10:30:00Z",
+  "level": "INFO",
+  "service": "ai-pattern-service",
+  "correlation_id": "abc-123",
+  "message": "Pattern analysis completed",
+  "duration_ms": 1234
+}
+```
+
+### Observability
+
+- **OpenTelemetry Tracing** - Distributed tracing across services
+- **Correlation IDs** - Request tracking across service boundaries
+- **Metrics** - Service health, database performance, pattern detection stats
+
+## Version History
+
+- **v1.0.0** (December 2025) - Initial service extraction from ai-automation-service (Epic 39, Story 39.5)
+  - Scheduled pattern analysis with cron support
+  - MQTT notification integration
+  - Incremental pattern updates
+  - Observability and structured logging
+
+---
+
+**Last Updated:** December 09, 2025
+**Version:** 1.0.0
+**Status:** Production Ready ✅
+**Port:** 8020 (internal) / 8034 (external)

--- a/services/ai-query-service/README.md
+++ b/services/ai-query-service/README.md
@@ -1,0 +1,380 @@
+# AI Query Service
+
+**Low-latency natural language query service for HomeIQ automation**
+
+**Port:** 8018 (internal), exposed as 8035 (external)
+**Technology:** Python 3.11+, FastAPI, SQLAlchemy
+**Container:** homeiq-ai-query-service
+**Database:** SQLite (ai_automation.db)
+**Scale:** Optimized for ~50-100 devices (single-home)
+
+## Overview
+
+The AI Query Service is a microservice extracted from ai-automation-service (Epic 39, Story 39.9) for independent scaling and low-latency query processing. It handles natural language automation queries with a target P95 latency of <500ms.
+
+**Port Mapping Note:** This service runs on port 8018 internally within the Docker network, but is exposed as port 8035 externally for host access. When making requests from outside Docker, use port 8035. Internal services should use port 8018.
+
+### Key Features
+
+- **Natural Language Processing** - Process user queries in natural language
+- **Entity Extraction** - Identify devices, rooms, and actions from queries using UnifiedExtractionPipeline
+- **Clarification Detection** - Detect ambiguous queries and request clarification
+- **Suggestion Generation** - Generate automation suggestions based on query intent
+- **Query Refinement** - Allow users to refine and improve suggestions
+- **Low-Latency Design** - Target P95 latency <500ms for interactive use
+- **Query Caching** - 5-minute TTL cache for repeated queries
+- **Parallel Extraction** - Enable parallel entity extraction for faster processing
+- **Observability** - OpenTelemetry tracing, correlation middleware, structured logging
+
+## API Endpoints
+
+### Health Endpoints
+
+```bash
+GET /health
+```
+Health check with database connectivity verification.
+
+**Response:**
+```json
+{
+  "status": "ok",
+  "database": "connected"
+}
+```
+
+```bash
+GET /ready
+```
+Kubernetes readiness probe endpoint.
+
+**Response:**
+```json
+{
+  "status": "ready"
+}
+```
+
+```bash
+GET /live
+```
+Kubernetes liveness probe endpoint.
+
+**Response:**
+```json
+{
+  "status": "live"
+}
+```
+
+### Service Info
+
+```bash
+GET /
+```
+Root endpoint with service information.
+
+**Response:**
+```json
+{
+  "service": "ai-query-service",
+  "version": "1.0.0",
+  "status": "operational"
+}
+```
+
+### Query Endpoints
+
+```bash
+POST /api/v1/query
+```
+Process natural language query and generate automation suggestions.
+
+**Request:**
+```json
+{
+  "query": "Turn on the living room lights when I get home",
+  "user_id": "user123",
+  "context": {
+    "location": "home",
+    "time": "evening"
+  }
+}
+```
+
+**Response:**
+```json
+{
+  "query_id": "query-abc123",
+  "status": "completed",
+  "message": "Query processed successfully",
+  "suggestions": [
+    {
+      "automation_id": "auto-1",
+      "description": "Turn on living room lights on arrival",
+      "confidence": 0.95
+    }
+  ],
+  "entities": [
+    {
+      "type": "device",
+      "value": "living room lights",
+      "entity_id": "light.living_room"
+    }
+  ]
+}
+```
+
+```bash
+GET /api/v1/query/{query_id}/suggestions
+```
+Get all suggestions for a specific query.
+
+**Response:**
+```json
+{
+  "query_id": "query-abc123",
+  "suggestions": [],
+  "total_count": 0,
+  "status": "completed"
+}
+```
+
+```bash
+POST /api/v1/query/{query_id}/refine
+```
+Refine query results based on user feedback.
+
+**Request:**
+```json
+{
+  "feedback": "Add sunset condition",
+  "selected_entities": ["light.living_room"]
+}
+```
+
+**Response:**
+```json
+{
+  "query_id": "query-abc123",
+  "status": "refined",
+  "message": "Query refined successfully"
+}
+```
+
+## Configuration
+
+### Environment Variables
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `DATABASE_PATH` | `/app/data/ai_automation.db` | Path to SQLite database file |
+| `DATABASE_URL` | `sqlite+aiosqlite:////app/data/ai_automation.db` | SQLAlchemy database URL |
+| `DATABASE_POOL_SIZE` | `10` | Database connection pool size (optimized for query service) |
+| `DATABASE_MAX_OVERFLOW` | `5` | Max overflow connections |
+| `DATA_API_URL` | `http://data-api:8006` | Data API service URL |
+| `DEVICE_INTELLIGENCE_URL` | `http://device-intelligence-service:8023` | Device intelligence service URL |
+| `SERVICE_PORT` | `8018` | Internal service port |
+| `SERVICE_NAME` | `ai-query-service` | Service name for logging/tracing |
+| `LOG_LEVEL` | `INFO` | Logging level (DEBUG, INFO, WARNING, ERROR) |
+
+#### Home Assistant Configuration
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `HA_URL` | `None` | Home Assistant URL (e.g., `http://192.168.1.86:8123`) |
+| `HA_TOKEN` | `None` | Home Assistant long-lived access token |
+
+#### OpenAI Configuration
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `OPENAI_API_KEY` | `None` | OpenAI API key for GPT-4o-mini |
+| `OPENAI_MODEL` | `gpt-4o-mini` | OpenAI model to use |
+| `OPENAI_TIMEOUT` | `30.0` | Timeout for OpenAI API calls (seconds) |
+
+#### Performance Settings
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `QUERY_TIMEOUT` | `5.0` | Max time for query processing (seconds) |
+| `MAX_QUERY_LENGTH` | `500` | Max characters in query |
+| `ENABLE_CACHING` | `True` | Enable query result caching |
+| `CACHE_TTL` | `300` | Cache TTL in seconds (5 minutes) |
+| `ENABLE_PARALLEL_EXTRACTION` | `True` | Enable parallel entity extraction |
+| `EXTRACTION_TIMEOUT` | `2.0` | Timeout for entity extraction (seconds) |
+
+#### Clarification Settings
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `CLARIFICATION_ENABLED` | `True` | Enable clarification detection |
+| `CLARIFICATION_CONFIDENCE_THRESHOLD` | `0.7` | Confidence threshold for clarification |
+| `MAX_CLARIFICATION_QUESTIONS` | `3` | Max clarification questions per query |
+
+## Development
+
+### Running Locally
+
+```bash
+cd services/ai-query-service
+python -m venv venv
+source venv/bin/activate  # On Windows: venv\Scripts\activate
+pip install -r requirements.txt
+uvicorn src.main:app --reload --port 8018
+```
+
+### Running with Docker
+
+```bash
+# Build and start service
+docker compose up -d ai-query-service
+
+# View logs
+docker compose logs -f ai-query-service
+
+# Test health endpoint (external port)
+curl http://localhost:8035/health
+
+# Test from inside Docker network (internal port)
+docker exec homeiq-ai-automation-ui curl http://ai-query-service:8018/health
+```
+
+### Testing Endpoints
+
+```bash
+# Health check
+curl http://localhost:8035/health
+
+# Process a query
+curl -X POST http://localhost:8035/api/v1/query \
+  -H "Content-Type: application/json" \
+  -d '{
+    "query": "Turn on the living room lights at sunset",
+    "user_id": "test-user"
+  }'
+
+# Get query suggestions
+curl http://localhost:8035/api/v1/query/query-abc123/suggestions
+```
+
+## Dependencies
+
+### Service Dependencies
+
+- **data-api** (Port 8006) - Historical data queries, device/entity metadata
+- **device-intelligence-service** (Port 8023) - Device capability information
+- **Home Assistant** - External instance for entity data and area information
+- **OpenAI API** - GPT-4o-mini for natural language processing
+- **SQLite Database** - Shared ai_automation.db for query history and suggestions
+
+### Python Dependencies
+
+- `fastapi` - Web framework
+- `uvicorn` - ASGI server
+- `sqlalchemy` - Database ORM
+- `aiosqlite` - Async SQLite driver
+- `pydantic` - Configuration management
+- `pydantic-settings` - Environment variable loading
+- `openai` - OpenAI API client
+- `shared` - HomeIQ shared libraries (logging, observability, error handling)
+
+## Related Services
+
+### Upstream Dependencies
+
+- **data-api** - Provides historical event data and device metadata
+- **device-intelligence-service** - Device capability discovery
+- **Home Assistant** - Entity registry and area information
+
+### Downstream Consumers
+
+- **ai-automation-ui** - Primary consumer for Ask AI tab
+- **health-dashboard** - Monitors query service health and performance
+
+## Architecture Notes
+
+### Separation from AI Automation Service
+
+This service was extracted from ai-automation-service in Epic 39, Story 39.9 to:
+- Enable independent scaling of query workloads
+- Optimize for low-latency interactive queries (<500ms P95)
+- Separate real-time query handling from batch pattern detection
+- Improve maintainability and deployment flexibility
+
+### Performance Optimization
+
+The service is optimized for low-latency query processing:
+1. **Query Timeout** - Hard 5-second timeout prevents hanging requests
+2. **Parallel Extraction** - Entity extraction runs in parallel when enabled
+3. **Result Caching** - 5-minute TTL cache for repeated queries
+4. **Connection Pooling** - Optimized database pool for query workload
+5. **Extraction Timeout** - 2-second timeout for entity extraction
+
+### Database Sharing
+
+This service shares the `ai_automation.db` SQLite database with ai-automation-service:
+- **Query History** - Stores processed queries for analytics
+- **Suggestion Cache** - Cached automation suggestions
+- **User Preferences** - Clarification preferences and feedback
+
+## Monitoring
+
+### Health Checks
+
+- **Liveness:** `GET /live` - Service is running
+- **Readiness:** `GET /ready` - Service is ready to accept traffic
+- **Health:** `GET /health` - Database connectivity verified
+
+### Performance Targets
+
+| Metric | Target | Acceptable | Investigation |
+|--------|--------|------------|---------------|
+| Query Processing | <500ms | <1s | >2s |
+| Entity Extraction | <2s | <3s | >5s |
+| Suggestion Generation | <3s | <5s | >10s |
+
+### Logging
+
+All logs follow structured logging format with correlation IDs:
+```json
+{
+  "timestamp": "2025-12-09T10:30:00Z",
+  "level": "INFO",
+  "service": "ai-query-service",
+  "correlation_id": "abc-123",
+  "message": "Query processed",
+  "duration_ms": 450,
+  "query_id": "query-abc123"
+}
+```
+
+### Observability
+
+- **OpenTelemetry Tracing** - Distributed tracing across services
+- **Correlation IDs** - Request tracking across service boundaries
+- **Metrics** - Query latency, cache hit rate, extraction performance
+
+## Security Notes
+
+- **TODO (Story 39.10):** Authentication middleware needs to be added before production deployment
+- **TODO (Story 39.10):** Rate limiting middleware needs to be added before production deployment
+- **CORS:** Currently allows specific origins (localhost:3000, localhost:3001, container networks)
+- **Input Validation:** Max query length enforced (500 characters)
+- **Timeouts:** All operations have configurable timeouts to prevent resource exhaustion
+
+## Version History
+
+- **v1.0.0** (December 2025) - Initial service extraction from ai-automation-service (Epic 39, Story 39.9)
+  - Foundation implementation with query endpoint
+  - Low-latency query processing (<500ms target)
+  - Query caching and parallel extraction
+  - Observability and structured logging
+  - **Note:** Full implementation will be completed in Story 39.10
+
+---
+
+**Last Updated:** December 09, 2025
+**Version:** 1.0.0
+**Status:** Development (Foundation Ready, Full Implementation in Story 39.10) 🚧
+**Port:** 8018 (internal) / 8035 (external)

--- a/services/device-intelligence-service/README.md
+++ b/services/device-intelligence-service/README.md
@@ -2,14 +2,17 @@
 
 **Centralized Device Discovery and Intelligence Processing for HomeIQ**
 
-**Port:** 8028
+**Port:** 8019 (internal), exposed as 8028 (external)
 **Technology:** Python 3.11+, FastAPI 0.121, SQLAlchemy 2.0, scikit-learn 1.7.2
 **Container:** `homeiq-device-intelligence`
 **Database:** SQLite (device_intelligence.db - 7 tables)
+**Scale:** Optimized for ~50-100 devices (single-home, not multi-home)
 
 ## Overview
 
 The Device Intelligence Service provides comprehensive device discovery, capability analysis, and intelligent recommendations for Home Assistant devices. It powers **Epic AI-2 (Device Intelligence)** by maintaining a SQLite database of discovered devices, their capabilities, and usage patterns, enabling fast lookups and predictive analytics.
+
+**Port Mapping Note:** The service runs on internal port 8019 but is exposed as port 8028 externally to avoid port conflicts with other services. All examples in this document use port 8028 (external) for production access. When developing locally without Docker, use port 8019.
 
 ### Key Features
 
@@ -45,8 +48,8 @@ pip install -r requirements.txt
 # Run database migrations
 alembic upgrade head
 
-# Start service
-uvicorn src.main:app --reload --port 8028
+# Start service (use internal port 8019 for local development)
+uvicorn src.main:app --reload --port 8019
 ```
 
 ### Running with Docker

--- a/services/ml-service/README.md
+++ b/services/ml-service/README.md
@@ -2,13 +2,17 @@
 
 **Classical Machine Learning for Pattern Detection and Analysis**
 
-**Port:** 8020
+**Port:** 8020 (internal), exposed as 8025 (external)
 **Technology:** Python 3.11+, FastAPI 0.121, scikit-learn 1.4, pandas 2.3
 **Container:** `homeiq-ml-service`
+**Database:** None (stateless ML service)
+**Scale:** Optimized for ~50-100 devices (single-home, not multi-home)
 
 ## Overview
 
 The ML Service provides classical machine learning algorithms for clustering, anomaly detection, and feature analysis. It complements deep learning models with traditional ML algorithms that are faster, more interpretable, and don't require pre-training for certain tasks.
+
+**Port Mapping Note:** The service runs on internal port 8020 but is exposed as port 8025 externally to avoid port conflicts with other services. All examples in this document use port 8025 (external) for production access. When developing locally without Docker, use port 8020.
 
 ### Key Features
 
@@ -53,7 +57,7 @@ docker compose up -d ml-service
 docker compose logs -f ml-service
 
 # Check health
-curl http://localhost:8020/health
+curl http://localhost:8025/health
 ```
 
 ## API Endpoints
@@ -63,7 +67,7 @@ curl http://localhost:8020/health
 #### `GET /health`
 Service health check
 ```bash
-curl http://localhost:8020/health
+curl http://localhost:8025/health
 ```
 
 ### Clustering
@@ -72,7 +76,7 @@ curl http://localhost:8020/health
 Group data points into clusters
 
 ```bash
-curl -X POST http://localhost:8020/cluster \
+curl -X POST http://localhost:8025/cluster \
   -H "Content-Type: application/json" \
   -d '{
     "data": [[1.0, 2.0], [1.5, 1.8], [5.0, 8.0], [5.5, 8.5]],
@@ -107,7 +111,7 @@ curl -X POST http://localhost:8020/cluster \
 Identify outliers in data
 
 ```bash
-curl -X POST http://localhost:8020/anomaly \
+curl -X POST http://localhost:8025/anomaly \
   -H "Content-Type: application/json" \
   -d '{
     "data": [[1.0, 1.0], [1.2, 1.1], [10.0, 10.0]],
@@ -139,7 +143,7 @@ curl -X POST http://localhost:8020/anomaly \
 Process multiple operations efficiently
 
 ```bash
-curl -X POST http://localhost:8020/batch/process \
+curl -X POST http://localhost:8025/batch/process \
   -H "Content-Type: application/json" \
   -d '{
     "operations": [
@@ -298,10 +302,10 @@ features = [
 
 ```bash
 # Health check
-curl http://localhost:8020/health
+curl http://localhost:8025/health
 
 # Test clustering
-curl -X POST http://localhost:8020/cluster \
+curl -X POST http://localhost:8025/cluster \
   -H "Content-Type: application/json" \
   -d '{
     "data": [[1.0, 2.0], [1.5, 1.8], [5.0, 8.0], [5.5, 8.5]],
@@ -310,7 +314,7 @@ curl -X POST http://localhost:8020/cluster \
   }'
 
 # Test anomaly detection
-curl -X POST http://localhost:8020/detect-anomalies \
+curl -X POST http://localhost:8025/detect-anomalies \
   -H "Content-Type: application/json" \
   -d '{
     "data": [[1.0, 1.0], [1.2, 1.1], [10.0, 10.0]],
@@ -422,10 +426,15 @@ pytest-asyncio==0.23.0    # Async test support
 
 - **Issues:** https://github.com/wtthornton/HomeIQ/issues
 - **Documentation:** `/docs` directory
-- **Health Check:** http://localhost:8020/health
-- **API Docs:** http://localhost:8020/docs
+- **Health Check:** http://localhost:8025/health
+- **API Docs:** http://localhost:8025/docs
 
 ## Version History
+
+### 2.2.1 (December 09, 2025)
+- Updated documentation to reflect port mapping (8020 internal, 8025 external)
+- Clarified port usage for Docker vs local development
+- Updated all API examples to use external port 8025
 
 ### 2.2 (November 15, 2025)
 - Added strict payload validation (10MB cap, 1000 dimensions, 100 clusters) and enforced documented batch limits
@@ -448,7 +457,7 @@ pytest-asyncio==0.23.0    # Async test support
 
 ---
 
-**Last Updated:** November 15, 2025
-**Version:** 2.1
+**Last Updated:** December 09, 2025
+**Version:** 2.2.1
 **Status:** Production Ready ✅
-**Port:** 8020
+**Port:** 8020 (internal), 8025 (external)

--- a/services/openvino-service/README.md
+++ b/services/openvino-service/README.md
@@ -2,13 +2,17 @@
 
 **Transformer-Based Embeddings and Re-ranking Service**
 
-**Port:** 8019
+**Port:** 8019 (internal), exposed as 8026 (external)
 **Technology:** Python 3.11+, FastAPI 0.121, sentence-transformers 3.3, PyTorch 2.3 (CPU)
 **Container:** `homeiq-openvino-service`
+**Database:** None (model inference only)
+**Scale:** Optimized for ~50-100 devices (single-home, not multi-home)
 
 ## Overview
 
 The OpenVINO Service provides transformer-based model inference for embeddings, re-ranking, and classification tasks. Originally designed for Intel OpenVINO optimization, it currently uses sentence-transformers with CPU-optimized PyTorch for broad compatibility.
+
+**Port Mapping Note:** The service runs on internal port 8019 but is exposed as port 8026 externally to avoid port conflicts with other services. All examples in this document use port 8026 (external) for production access. When developing locally without Docker, use port 8019.
 
 **Note:** Service name retained for API compatibility. OpenVINO quantization temporarily removed due to dependency conflicts; currently using standard sentence-transformers models.
 
@@ -59,7 +63,7 @@ docker compose up -d openvino-service
 docker compose logs -f openvino-service
 
 # Check health
-curl http://localhost:8019/health
+curl http://localhost:8026/health
 ```
 
 ## API Endpoints
@@ -69,7 +73,7 @@ curl http://localhost:8019/health
 #### `GET /health`
 Service health check
 ```bash
-curl http://localhost:8019/health
+curl http://localhost:8026/health
 ```
 
 ### Text Embeddings
@@ -78,7 +82,7 @@ curl http://localhost:8019/health
 Convert text to 1024-dimensional embeddings (max 100 texts, 4,000 chars each by default) [Epic 47: BGE-Large]
 
 ```bash
-curl -X POST http://localhost:8019/embeddings \
+curl -X POST http://localhost:8026/embeddings \
   -H "Content-Type: application/json" \
   -d '{
     "texts": ["office light", "bedroom lamp"],
@@ -109,7 +113,7 @@ curl -X POST http://localhost:8019/embeddings \
 Re-rank candidates based on query relevance (max 200 candidates / top_k capped at 50)
 
 ```bash
-curl -X POST http://localhost:8019/rerank \
+curl -X POST http://localhost:8026/rerank \
   -H "Content-Type: application/json" \
   -d '{
     "query": "office light 1",
@@ -151,7 +155,7 @@ curl -X POST http://localhost:8019/rerank \
 Classify automation patterns (pattern description up to 4,000 chars by default)
 
 ```bash
-curl -X POST http://localhost:8019/classify \
+curl -X POST http://localhost:8026/classify \
   -H "Content-Type: application/json" \
   -d '{
     "pattern_description": "Turn on office lights at 6 PM on weekdays"
@@ -333,15 +337,15 @@ category = await classify(description)
 
 ```bash
 # Health check
-curl http://localhost:8019/health
+curl http://localhost:8026/health
 
 # Generate embeddings
-curl -X POST http://localhost:8019/embed \
+curl -X POST http://localhost:8026/embed \
   -H "Content-Type: application/json" \
   -d '{"texts": ["office light", "bedroom lamp"], "normalize": true}'
 
 # Re-rank candidates
-curl -X POST http://localhost:8019/rerank \
+curl -X POST http://localhost:8026/rerank \
   -H "Content-Type: application/json" \
   -d '{
     "query": "office light",
@@ -352,7 +356,7 @@ curl -X POST http://localhost:8019/rerank \
   }'
 
 # Classify pattern
-curl -X POST http://localhost:8019/classify \
+curl -X POST http://localhost:8026/classify \
   -H "Content-Type: application/json" \
   -d '{"pattern_description": "Turn on lights at sunset"}'
 ```
@@ -497,8 +501,8 @@ Logs include:
 
 - **Issues:** https://github.com/wtthornton/HomeIQ/issues
 - **Documentation:** `/docs` directory
-- **Health Check:** http://localhost:8019/health
-- **API Docs:** http://localhost:8019/docs
+- **Health Check:** http://localhost:8026/health
+- **API Docs:** http://localhost:8026/docs
 
 ## Version History
 


### PR DESCRIPTION
Updated all service documentation to reflect accurate port mappings and added comprehensive
port mapping reference documentation.

Changes:
- Created PORT_MAPPING_REFERENCE.md: Complete guide to Docker port mappings (external vs internal)
- Created service READMEs: ai-pattern-service, ai-query-service (with port mapping notes)
- Updated service READMEs with port clarifications:
  - ml-service: 8020 (internal) → 8025 (external)
  - device-intelligence-service: 8019 (internal) → 8028 (external)
  - openvino-service: 8019 (internal) → 8026 (external)
  - energy-correlator, ha-setup-service, log-aggregator: Port clarifications
- Updated CLAUDE.md v5.0.1:
  - Added PORT_MAPPING_REFERENCE.md to documentation structure
  - Updated "Finding Documentation" table
  - Added changelog for v5.0.1

Documentation Coverage:
- All 24+ active services now have comprehensive READMEs
- Port mapping conflicts documented and explained
- External vs internal port usage clarified
- Service-to-service communication patterns documented

Related Epics: Epic 31 (Direct InfluxDB Writes), Epic 39 (AI Services), Epic 47 (Embeddings)